### PR TITLE
Change translator path/url to local janus assets translators folder

### DIFF
--- a/src/mathutil.cpp
+++ b/src/mathutil.cpp
@@ -1904,7 +1904,8 @@ QRectF MathUtil::GetStringAsRect(const QString & s)
 
 QString MathUtil::GetTranslatorPath()
 {
-    return QString("http://downloads.janusvr.com/translator/");
+    // Temporary, needs check for os type for pathing.
+    return QString("file://" + GetApplicationPath() + "assets/translators/");
 }
 
 QString MathUtil::GetPath_Util(const QString subdir)


### PR DESCRIPTION
This needs to be merged together with the site_translator_reintegration branch for the local translators to work.
There is more work to be done on the translators since there has been large changes to the sites like Imgur and probably others more or less rendering them useless at the moment.