### PR TITLE
Fix lib build issues part 2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,10 +6,6 @@
 	path = resources/openssl-1.1.1g
 	url = https://github.com/panmarco83/openssl.git
 	ignore = dirty
-[submodule "resources/openvr-1.12.5"]
-	path = resources/openvr-1.12.5
-	url = https://github.com/panmarco83/openvr.git
-	ignore = dirty
 [submodule "resources/opus-1.3.1"]
 	path = resources/opus-1.3.1
 	url = https://github.com/panmarco83/opus.git
@@ -17,4 +13,8 @@
 [submodule "resources/assimp-5.0.1"]
 	path = resources/assimp-5.0.1
 	url = https://github.com/assimp/assimp.git
+	ignore = dirty
+[submodule "resources/openvr-1.12.5"]
+	path = resources/openvr-1.12.5
+	url = https://github.com/ValveSoftware/openvr.git
 	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "resources/assimp-5.0.1"]
-	path = resources/assimp-5.0.1/
-	url = https://github.com/panmarco83/assimp.git
-	ignore = dirty
 [submodule "resources/openal-soft-1.20.1"]
 	path = resources/openal-soft-1.20.1
 	url = https://github.com/panmarco83/openal-soft.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 	path = resources/openvr-1.12.5
 	url = https://github.com/ValveSoftware/openvr.git
 	ignore = dirty
+[submodule "resources/assimp"]
+	path = resources/assimp
+	url = https://github.com/assimp/assimp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,7 @@
 	path = resources/opus-1.3.1
 	url = https://github.com/panmarco83/opus.git
 	ignore = dirty
+[submodule "resources/assimp-5.0.1"]
+	path = resources/assimp-5.0.1
+	url = https://github.com/panmarco83/assimp.git
+	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,7 @@
 	path = resources/opus-1.3.1
 	url = https://github.com/panmarco83/opus.git
 	ignore = dirty
+[submodule "resources/assimp-5.0.1"]
+	path = resources/assimp-5.0.1
+	url = https://github.com/assimp/assimp.git
+	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,4 @@
 [submodule "resources/assimp"]
 	path = resources/assimp
 	url = https://github.com/assimp/assimp.git
+	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,7 +14,3 @@
 	path = resources/opus-1.3.1
 	url = https://github.com/panmarco83/opus.git
 	ignore = dirty
-[submodule "resources/assimp-5.0.1"]
-	path = resources/assimp-5.0.1
-	url = https://github.com/panmarco83/assimp.git
-	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,10 +10,6 @@
 	path = resources/opus-1.3.1
 	url = https://github.com/panmarco83/opus.git
 	ignore = dirty
-[submodule "resources/assimp-5.0.1"]
-	path = resources/assimp-5.0.1
-	url = https://github.com/assimp/assimp.git
-	ignore = dirty
 [submodule "resources/openvr-1.12.5"]
 	path = resources/openvr-1.12.5
 	url = https://github.com/ValveSoftware/openvr.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,20 +1,20 @@
 [submodule "resources/assimp-5.0.1"]
 	path = resources/assimp-5.0.1/
-	url = git@github.com:panmarco83/assimp.git
+	url = https://github.com/panmarco83/assimp.git
 	ignore = dirty
 [submodule "resources/openal-soft-1.20.1"]
 	path = resources/openal-soft-1.20.1
-	url = git@github.com:panmarco83/openal-soft.git
+	url = https://github.com/panmarco83/openal-soft.git
 	ignore = dirty
 [submodule "resources/openssl-1.1.1g"]
 	path = resources/openssl-1.1.1g
-	url = git@github.com:panmarco83/openssl.git
+	url = https://github.com/panmarco83/openssl.git
 	ignore = dirty
 [submodule "resources/openvr-1.12.5"]
 	path = resources/openvr-1.12.5
-	url = git@github.com:panmarco83/openvr.git
+	url = https://github.com/panmarco83/openvr.git
 	ignore = dirty
 [submodule "resources/opus-1.3.1"]
 	path = resources/opus-1.3.1
-	url = git@github.com:panmarco83/opus.git
+	url = https://github.com/panmarco83/opus.git
 	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,4 +17,3 @@
 [submodule "resources/assimp"]
 	path = resources/assimp
 	url = https://github.com/assimp/assimp.git
-	ignore = dirty

--- a/FireBox.pro
+++ b/FireBox.pro
@@ -5,7 +5,7 @@
 #-------------------------------------------------
 
 # Define version
-__VERSION=66.4
+__VERSION=66.4.1
 
 #JamesMcCrae: define this when doing Oculus-submitted builds
 #DEFINES += OCULUS_SUBMISSION_BUILD
@@ -20,21 +20,21 @@ DEFINES += RIFT_ID=\\\"$$system(cat riftid.txt)\\\"
 }
 
 # ensure one "debug_and_release" in CONFIG, for clarity...
-debug_and_release {
-    CONFIG -= debug_and_release
-    CONFIG += debug_and_release
-}
-    # ensure one "debug" or "release" in CONFIG so they can be used as
-    #   conditionals instead of writing "CONFIG(debug, debug|release)"...
-CONFIG(debug, debug|release) {
-    CONFIG -= debug release
-    CONFIG += debug
-}
-CONFIG(release, debug|release) {
-    CONFIG -= debug release
-    CONFIG += release force_debug_info
+#debug_and_release {
+#    CONFIG -= debug_and_release
+#    CONFIG += debug_and_release
+#}
+# ensure one "debug" or "release" in CONFIG so they can be used as
+#   conditionals instead of writing "CONFIG(debug, debug|release)"...
+#CONFIG(debug, debug|release) {
+#    CONFIG -= debug release
+#    CONFIG += debug
+#}
+#CONFIG(release, debug|release) {
+#    CONFIG -= debug release
+#    CONFIG += release force_debug_info
 # force_debug_info
-}
+#}
 
 QT       += core opengl gui network xml script scripttools webengine webenginewidgets websockets
 

--- a/FireBox.pro
+++ b/FireBox.pro
@@ -287,7 +287,7 @@ unix:INCLUDEPATH += "/usr/include/bullet"
 unix:LIBS += -lBulletDynamics -lBulletCollision -lLinearMath
 
 # Assimp
-INCLUDEPATH += "./resources/assimp/include"
+INCLUDEPATH += "./resources/assimp/include/assimp"
 
 CONFIG(debug) {
     LIBS += -L"$$PWD/resources/assimp/lib/Debug"

--- a/FireBox.pro
+++ b/FireBox.pro
@@ -242,12 +242,12 @@ win32:LIBS += -llibOVR
 
 # openVR (note that we only include it if OCULUS_SUBMISSION_BUILD is not defined)
 !contains(DEFINES, OCULUS_SUBMISSION_BUILD) {
-win32:INCLUDEPATH += "./resources/openvr/headers"
-win32:LIBS += -L"$$PWD/resources/openvr/lib/win64"
+win32:INCLUDEPATH += "./resources/openvr-1.12.5/headers"
+win32:LIBS += -L"$$PWD/resources/openvr-1.12.5/lib/win64"
 win32:LIBS += -lopenvr_api
 }
-unix:INCLUDEPATH += "./resources/openvr/headers"
-unix:LIBS += -L"$$PWD/resources/openvr/lib/linux64"
+unix:INCLUDEPATH += "./resources/openvr-1.12.5/headers"
+unix:LIBS += -L"$$PWD/resources/openvr-1.12.5/lib/linux64"
 unix:LIBS += -lopenvr_api
 
 # OpenAL

--- a/FireBox.pro
+++ b/FireBox.pro
@@ -287,17 +287,17 @@ unix:INCLUDEPATH += "/usr/include/bullet"
 unix:LIBS += -lBulletDynamics -lBulletCollision -lLinearMath
 
 # Assimp
-INCLUDEPATH += "./resources/assimp-5.0.1/include"
+INCLUDEPATH += "./resources/assimp/include"
 
 CONFIG(debug) {
-    LIBS += -L"$$PWD/resources/assimp-5.0.1/lib/Debug"
+    LIBS += -L"$$PWD/resources/assimp/lib/Debug"
     win32:LIBS += -lassimp-vc140-mt -lIrrXML
 }
 CONFIG(release) {
-    LIBS += -L"$$PWD/resources/assimp-5.0.1/lib/Release"
+    LIBS += -L"$$PWD/resources/assimp/lib/Release"
     win32:LIBS += -lassimp-vc140-mt -lIrrXML
 }
-LIBS += -L"$$PWD/resources/assimp-5.0.1/lib"
+LIBS += -L"$$PWD/resources/assimp/lib"
 unix:LIBS += -lassimp
 
 # Generic Windows libs

--- a/FireBox.pro
+++ b/FireBox.pro
@@ -287,7 +287,7 @@ unix:INCLUDEPATH += "/usr/include/bullet"
 unix:LIBS += -lBulletDynamics -lBulletCollision -lLinearMath
 
 # Assimp
-INCLUDEPATH += "./resources/assimp/include/assimp"
+INCLUDEPATH += "./resources/assimp/include"
 
 CONFIG(debug) {
     LIBS += -L"$$PWD/resources/assimp/lib/Debug"

--- a/README.md
+++ b/README.md
@@ -57,17 +57,17 @@ Building for Linux (Ubuntu 18.04 LTS)
 === Automated script ===
 
 1) Clone the repository using Git:
-	`git clone https://github.com/janusvr/janus`
+	- `git clone https://github.com/janusvr/janus`
 
 2) Change directory into source directory and fetch submodules needed:
-  `cd janus`
-  `git submodule init`
-  `git submodule update`
+  - `cd janus`
+  - `git submodule init`
+  - `git submodule update`
 
-2) Run the automated build script:
-	`./build-janusvr-linux.sh`
+3) Run the automated build script:
+	- `./build-janusvr-linux.sh`
 
-3) Once completed, your new JanusVR build can be found inside `dist/linux/` in the root of your source repo.
+4) Once completed, your new JanusVR build can be found inside `dist/linux/` in the root of your source repo.
    To run Janus, just type `dist/linux/janusvr -render 2d`
 
 === Via command line ===

--- a/README.md
+++ b/README.md
@@ -59,7 +59,12 @@ Building for Linux (Ubuntu 18.04 LTS)
 1) Clone the repository using Git:
 	`git clone https://github.com/janusvr/janus`
 
-2) Change to the source directory (`cd janus`) and run the automated build script:
+2) Change directory into source directory and fetch submodules needed:
+  `cd janus`
+  `git submodule init`
+  `git submodule update`
+
+2) Run the automated build script:
 	`./build-janusvr-linux.sh`
 
 3) Once completed, your new JanusVR build can be found inside `dist/linux/` in the root of your source repo.

--- a/build-janusvr-linux.sh
+++ b/build-janusvr-linux.sh
@@ -136,7 +136,7 @@ build_assimp () {
 	echo -e "( this can be skipped by using the -a or --nobuildai flag )"
 	cd resources/build_dir/assimp-5.0.1/
 	cmake ../../assimp-5.0.1/ -B .
-	make -j $(nproc --ignore=4)
+	make -j $NPROC
 	cd ../../../
 }
 
@@ -154,7 +154,7 @@ build_openvr () {
 	echo -e "( this can be skipped by using the -o or --nobuildovr flag )"
 	cd resources/build_dir/openvr-1.12.5/
 	cmake -B$(pwd)/ ../../openvr-1.12.5/
-	make
+	make -j $NPROC
 	cd ../../../
 }
 

--- a/build-janusvr-linux.sh
+++ b/build-janusvr-linux.sh
@@ -135,7 +135,7 @@ build_assimp () {
 	echo -e "\n[*] Building ASSet IMPorter v5.0.1"
 	echo -e "    ( this can be skipped by using the -a or --nobuildai flag )"
 	cd resources/build_dir/assimp-5.0.1/
-	cmake "../../assimp-5.0.1/" -B .
+	cmake ../../assimp-5.0.1/ -B .
 	make -j $NPROC
 	cd ../../../
 }

--- a/build-janusvr-linux.sh
+++ b/build-janusvr-linux.sh
@@ -147,10 +147,10 @@ build_assimp () {
 
 copy_assimp () {
 	echo -e "\n[*] Copying assimp to $BUILD_DIR"
-	cp resources/assimp-5.0.1/lib/libassimp.so.5.0.0 $BUILD_DIR
+	cp resources/assimp-5.0.1/bin/libassimp.so.5.0.1 $BUILD_DIR
 	cd $BUILD_DIR
-	ln -s libassimp.so.5.0.0 libassimp.so.5
-	ln -s libassimp.so.5.0.0 libassimp.so
+	ln -s libassimp.so.5.0.1 libassimp.so.5
+	ln -s libassimp.so.5.0.1 libassimp.so
 	cd ../../
 }
 

--- a/build-janusvr-linux.sh
+++ b/build-janusvr-linux.sh
@@ -140,10 +140,10 @@ build_assimp () {
 
 copy_assimp () {
 	echo -e "\n[*] Copying assimp to $BUILD_DIR"
-	cp resources/assimp/lib/libassimp.so.5.0.1 $BUILD_DIR
+	cp resources/assimp/lib/libassimp.so.5.0.0 $BUILD_DIR
 	cd $BUILD_DIR
-	ln -s libassimp.so.5.0.1 libassimp.so.5
-	ln -s libassimp.so.5.0.1 libassimp.so
+	ln -s libassimp.so.5.0.0 libassimp.so.5
+	ln -s libassimp.so.5.0.0 libassimp.so
 	cd ../../
 }
 

--- a/build-janusvr-linux.sh
+++ b/build-janusvr-linux.sh
@@ -10,6 +10,9 @@ NPROC=
 TIMEBUILD=false
 HELP=false
 BUILD_DIR="dist/linux/"
+WITHDEBUG=
+QDB="CONFIG-=force_debug_info CONFIG-=debug_and_release CONFIG-=debug CONFIG+=release"
+MDB=
 
 BUILDFAIL=false
 
@@ -22,9 +25,11 @@ do
 			;;
 		-a | --nobuildai ) BUILDAI=false
 			;;
+		-b | --debug ) WITHDEBUG=true; QDB="CONFIG+=force_debug_info"
+			;;
 		-v | --verbose ) VERBOSE=true
 			;;
-		-tb | --timebuild ) TIME=false
+		-t | --timebuild ) TIME=false
 			;;
 		-t | --threads ) NPROC="$2"
 			;;
@@ -93,10 +98,10 @@ build_janus () {
 	echo -e "\n[*] Building JanusVR Native binary distribution using $NPROC threads. Please wait..."
 	if [ "$TIMEBUILD" = true ]
 	then
-		qmake FireBox.pro -spec linux-g++ CONFIG+=release CONFIG+=force_debug_info
+		qmake FireBox.pro -spec linux-g++ CONFIG+=release $QDB
 		time { make -j$NPROC $QUIET; }
 	else
-		qmake FireBox.pro -spec linux-g++ CONFIG+=release CONFIG+=force_debug_info
+		qmake FireBox.pro -spec linux-g++ CONFIG+=release $QDB
 		make -j$NPROC $QUIET;
 	fi
 }
@@ -168,6 +173,7 @@ display_help_text () {
 	echo " -d   --nodepinst     Skip dependency installation"
 	echo " -o   --nobuildovr    Skip build and install of OpenVR"
 	echo " -a   --nobuildai     Skip build and install of AssImp"
+	echo " -b   --debug         Include debug symbols"
 	echo " -v   --verbose       Verbose display of build process"
 	echo " -t   --threads N     Number of threads to use in build process"
 	echo " -h   --help          Display this help page"

--- a/build-janusvr-linux.sh
+++ b/build-janusvr-linux.sh
@@ -74,7 +74,7 @@ pkglist=(
 
 install_dependencies () {
 	echo -e "\n[*] Installing prerequisite OS packages for Ubuntu 18.04"
-	echo -e "( this can be skipped by using the -d or --nodepinst flag )"
+	echo -e "    ( this can be skipped by using the -d or --nodepinst flag )"
 	sudo apt install ${pkglist[@]}
 }
 
@@ -86,7 +86,7 @@ header_text () {
 
 footer_text () {
 	echo "\n[*] Done! Please run 'janusvr' from $BUILD_DIR"
-	echo "( Use -h or --help for build options )"
+	echo "    ( Use -h or --help for build options )"
 }
 
 build_janus () {
@@ -133,9 +133,9 @@ create_library_build_folders () {
 
 build_assimp () {
 	echo -e "\n[*] Building ASSet IMPorter v5.0.1"
-	echo -e "( this can be skipped by using the -a or --nobuildai flag )"
+	echo -e "    ( this can be skipped by using the -a or --nobuildai flag )"
 	cd resources/build_dir/assimp-5.0.1/
-	cmake ../../assimp-5.0.1/ -B .
+	cmake "../../assimp-5.0.1/" -B .
 	make -j $NPROC
 	cd ../../../
 }
@@ -151,7 +151,7 @@ copy_assimp () {
 
 build_openvr () {
 	echo -e "\n[*] Building OpenVR v1.12.5"
-	echo -e "( this can be skipped by using the -o or --nobuildovr flag )"
+	echo -e "    ( this can be skipped by using the -o or --nobuildovr flag )"
 	cd resources/build_dir/openvr-1.12.5/
 	cmake -B$(pwd)/ ../../openvr-1.12.5/
 	make -j $NPROC

--- a/build-janusvr-linux.sh
+++ b/build-janusvr-linux.sh
@@ -13,8 +13,9 @@ BUILD_DIR="dist/linux/"
 WITHDEBUG=
 QDB="CONFIG-=force_debug_info CONFIG-=debug_and_release CONFIG-=debug CONFIG+=release"
 MDB=
-
+UV=$(lsb_release -r -s)
 BUILDFAIL=false
+pkglist=
 
 while test $# -gt 0
 do
@@ -43,42 +44,81 @@ do
 	shift
 done
 
-pkglist=(
-	cmake
-	qtcreator
-	qt5-default
-	build-essential
-	mesa-common-dev
-	git
-	git-lfs
-	build-essential
-	libqt5websockets5-dev
-	libbullet-dev
-	libopenal-dev
-	libopus-dev
-	libvorbis-dev
-	libudev-dev
-	libvlc-dev
-	libopenexr-dev
-	libudev-dev
-	vlc
-	zlib1g-dev
-	qt5-default
-	qtscript5-dev
-	mesa-common-dev
-	libilmbase-dev
-	#libassimp-dev
-	qtbase5-private-dev
-	libqt5webengine5
-	libqt5webenginecore5
-	libqt5webenginewidgets5
-	qtwebengine5-dev
-	libqt5scripttools5
-	qtscript-tools
-	)
+
+
+if [[ $UV == "18.04" ]];
+then
+	pkglist=(
+		cmake
+		qtcreator
+		qt5-default
+		build-essential
+		mesa-common-dev
+		git
+		git-lfs
+		build-essential
+		libqt5websockets5-dev
+		libbullet-dev
+		libopenal-dev
+		libopus-dev
+		libvorbis-dev
+		libudev-dev
+		libvlc-dev
+		libopenexr-dev
+		libudev-dev
+		vlc
+		zlib1g-dev
+		qt5-default
+		qtscript5-dev
+		mesa-common-dev
+		libilmbase-dev
+		qtbase5-private-dev
+		libqt5webengine5
+		libqt5webenginecore5
+		libqt5webenginewidgets5
+		qtwebengine5-dev
+		libqt5scripttools5
+		qtscript-tools
+		)
+elif [[ $UV == "20.04" ]];
+then
+	pkglist=(
+		cmake
+		qtcreator
+		qt5-default
+		build-essential
+		mesa-common-dev
+		git
+		git-lfs
+		build-essential
+		libqt5websockets5-dev
+		libbullet-dev
+		libopenal-dev
+		libopus-dev
+		libvorbis-dev
+		libudev-dev
+		libvlc-dev
+		libopenexr-dev
+		libudev-dev
+		vlc
+		zlib1g-dev
+		qt5-default
+		qtscript5-dev
+		mesa-common-dev
+		libilmbase-dev
+		qtbase5-private-dev
+		libqt5webengine5
+		libqt5webenginecore5
+		libqt5webenginewidgets5
+		qtwebengine5-dev
+		libqt5scripttools5
+		)
+else
+	echo "not ubuntu"
+fi
 
 install_dependencies () {
-	echo -e "\n[*] Installing prerequisite OS packages for Ubuntu 18.04"
+	echo -e "\n[*] Installing prerequisite OS packages for Ubuntu $UV"
 	echo -e "    ( this can be skipped by using the -d or --nodepinst flag )"
 	sudo apt install ${pkglist[@]}
 }

--- a/build-janusvr-linux.sh
+++ b/build-janusvr-linux.sh
@@ -1,4 +1,43 @@
 #!/bin/bash -E
+
+INSTALLDEPS=true
+BUILDOVR=true
+BUILDAI=true
+QUIET=
+CQUIET=
+VERBOSE=false
+NPROC=
+TIMEBUILD=false
+HELP=false
+BUILD_DIR="dist/linux/"
+
+BUILDFAIL=false
+
+while test $# -gt 0
+do
+	case "$1" in 
+		-d | --nodepinst ) INSTALLDEPS=false
+			;;
+		-o | --nobuildovr ) BUILDOVR=false
+			;;
+		-a | --nobuildai ) BUILDAI=false
+			;;
+		-v | --verbose ) VERBOSE=true
+			;;
+		-tb | --timebuild ) TIME=false
+			;;
+		-t | --threads ) NPROC="$2"
+			;;
+		-h | --help ) HELP=true
+			;;
+		--* ) echo "unknown argument '$1'"
+			;;
+		*) NPROC=$1
+			;;
+	esac
+	shift
+done
+
 pkglist=(
 	cmake
 	qtcreator
@@ -9,7 +48,6 @@ pkglist=(
 	git-lfs
 	build-essential
 	libqt5websockets5-dev
-	qtscript-tools
 	libbullet-dev
 	libopenal-dev
 	libopus-dev
@@ -30,62 +68,178 @@ pkglist=(
 	libqt5webenginecore5
 	libqt5webenginewidgets5
 	qtwebengine5-dev
+	libqt5scripttools5
+	qtscript-tools
 	)
 
-# TODO: Enable automatic package installation via CLI flag
-echo -e "\n[*] Installing prerequisite OS packages for Ubuntu 18.04"
-sudo apt install ${pkglist[@]}
+install_dependencies () {
+	echo -e "\n[*] Installing prerequisite OS packages for Ubuntu 18.04"
+	echo -e "( this can be skipped by using the -d or --nodepinst flag )"
+	sudo apt install ${pkglist[@]}
+}
 
-echo "########################################################"
-echo " Welcome to the magical Linux Auto Compiler for JanusVR "
-echo "########################################################"
+header_text () {
+	echo "########################################################"
+	echo " Welcome to the magical Linux Auto Compiler for JanusVR "
+	echo "########################################################"
+}
 
-BUILD_DIR="dist/linux/"
+footer_text () {
+	echo "\n[*] Done! Please run 'janusvr' from $BUILD_DIR"
+	echo "( Use -h or --help for build options )"
+}
 
-NPROC=$(nproc --ignore=4) #So some computer usage is still possible
+build_janus () {
+	echo -e "\n[*] Building JanusVR Native binary distribution using $NPROC threads. Please wait..."
+	if [ "$TIMEBUILD" = true ]
+	then
+		qmake FireBox.pro -spec linux-g++ CONFIG+=release CONFIG+=force_debug_info
+		time { make -j$NPROC $QUIET; }
+	else
+		qmake FireBox.pro -spec linux-g++ CONFIG+=release CONFIG+=force_debug_info
+		make -j$NPROC $QUIET;
+	fi
+}
 
-echo -e "\n[*] Building JanusVR Native binary distribution with $NPROC processors. Please wait..."
-qmake FireBox.pro -spec linux-g++ CONFIG+=release CONFIG+=force_debug_info
-time { make -j$NPROC; }
+remove_build_folder () {
+	echo -e "\n[*] Deleting build dir $BUILD_DIR"
+	rm -rf $BUILD_DIR
+}
 
-# remove previous build attempts in case of failed compilations
-echo -e "\n[*] Deleting build dir $BUILD_DIR"
-rm -rf $BUILD_DIR
+create_build_folder () {
+	echo -e "\n[*] Creating directory for build distribution in $BUILD_DIR..."
+	mkdir -p $BUILD_DIR
+}
 
-echo -e "\n[*] Creating directory for build distribution in $BUILD_DIR..."
-mkdir -p $BUILD_DIR
-cp janusvr $BUILD_DIR
-ln -s $(pwd)/assets $BUILD_DIR/assets
-cp -r dependencies/linux/* $BUILD_DIR
+copy_janus_binary_and_assets () {
+	cp janusvr $BUILD_DIR
+	ln -s $(pwd)/assets $(pwd)/$BUILD_DIR/assets
+	cp -r dependencies/linux/* $BUILD_DIR
+}
 
-echo -e "\n[#] PATCH 1: Adding depedencies from OS to distribution directory"
-cp /usr/lib/x86_64-linux-gnu/libBulletDynamics.so.2.87	$BUILD_DIR
-cp /usr/lib/x86_64-linux-gnu/libBulletCollision.so.2.87	$BUILD_DIR
-cp /usr/lib/x86_64-linux-gnu/libLinearMath.so.2.87		$BUILD_DIR
+bullet_patch () {
+	echo -e "\n[#] PATCH 1: Adding depedencies from OS to distribution directory"
+	cp /usr/lib/x86_64-linux-gnu/libBulletDynamics.so.2.87	$BUILD_DIR
+	cp /usr/lib/x86_64-linux-gnu/libBulletCollision.so.2.87	$BUILD_DIR
+	cp /usr/lib/x86_64-linux-gnu/libLinearMath.so.2.87		$BUILD_DIR
+}
 
-echo -e "\n[*] Create Library build folder"
-mkdir resources/build_dir/
-mkdir resources/build_dir/assimp-5.0.1/
-mkdir resources/build_dir/openvr-1.12.5/
+create_library_build_folders () {
+	echo -e "\n[*] Create Library build folder"
+	mkdir -p resources/build_dir/
+	mkdir -p resources/build_dir/assimp-5.0.1/
+	mkdir -p resources/build_dir/openvr-1.12.5/
+}
 
-echo -e "\n[*] Building ASSet IMPorter v5.0.1"
-cd resources/build_dir/assimp-5.0.1/
-cmake ../../assimp-5.0.1/ -B .
-make -j $(nproc --ignore=4)
-cd ../../../
-echo -e "\n[*] Copying assimp to $BUILD_DIR"
-cp resources/build_dir/assimp-5.0.1/code/libassimp.so.5.0.0 $BUILD_DIR
-cd $BUILD_DIR
-ln -s libassimp.so.5.0.0 libassimp.so.5
-ln -s libassimp.so.5.0.0 libassimp.so
-cd ../../
+build_assimp () {
+	echo -e "\n[*] Building ASSet IMPorter v5.0.1"
+	echo -e "( this can be skipped by using the -a or --nobuildai flag )"
+	cd resources/build_dir/assimp-5.0.1/
+	cmake ../../assimp-5.0.1/ -B .
+	make -j $(nproc --ignore=4)
+	cd ../../../
+}
 
-echo -e "\n[*] Building OpenVR v1.12.5"
-cd resources/build_dir/openvr-1.12.5/
-cmake -B$(pwd)/ ../../openvr-1.12.5/
-make
-cd ../../../
-echo -e "\n[*] Copying OpenVR to $BUILD_DIR"
-cp resources/openvr-1.12.5/bin/linux64/libopenvr_api.so $BUILD_DIR
+copy_assimp () {
+	echo -e "\n[*] Copying assimp to $BUILD_DIR"
+	cp resources/build_dir/assimp-5.0.1/code/libassimp.so.5.0.0 $BUILD_DIR
+	cd $BUILD_DIR
+	ln -s libassimp.so.5.0.0 libassimp.so.5
+	ln -s libassimp.so.5.0.0 libassimp.so
+	cd ../../
+}
 
-echo -e "\n[*] Done! Please run 'janusvr' from $BUILD_DIR"
+build_openvr () {
+	echo -e "\n[*] Building OpenVR v1.12.5"
+	echo -e "( this can be skipped by using the -o or --nobuildovr flag )"
+	cd resources/build_dir/openvr-1.12.5/
+	cmake -B$(pwd)/ ../../openvr-1.12.5/
+	make
+	cd ../../../
+}
+
+copy_openvr () {
+	echo -e "\n[*] Copying OpenVR to $BUILD_DIR"
+	cp resources/openvr-1.12.5/bin/linux64/libopenvr_api.so $BUILD_DIR
+}
+
+display_help_text () {
+	echo " Usage: $0 [options] [arguments]\n"
+	echo " -d   --nodepinst     Skip dependency installation"
+	echo " -o   --nobuildovr    Skip build and install of OpenVR"
+	echo " -a   --nobuildai     Skip build and install of AssImp"
+	echo " -v   --verbose       Verbose display of build process"
+	echo " -t   --threads N     Number of threads to use in build process"
+	echo " -h   --help          Display this help page"
+}
+
+main () {
+	if [ "$HELP" = true ]
+	then
+		display_help_text
+	fi
+
+	if [ "$HELP" = false ]
+	then
+		if [ "$INSTALLDEPS" = true ]
+		then
+			install_dependencies
+		fi
+		remove_build_folder
+		create_build_folder
+	fi
+
+	if [ "$VERBOSE" = false ] && [ "$HELP" = false ]
+	then
+		QUIET=" -s "
+		CQUIET=""
+	fi
+
+	if [ ! -z "$NPROC" ]
+	then
+		if [ "$HELP" = false ]
+		then
+			build_janus
+			copy_janus_binary_and_assets
+					
+		fi
+	else
+		if [ "$HELP" = false ]
+		then
+			NPROC=$(nproc)
+			build_janus
+			copy_janus_binary_and_assets
+					
+		fi
+	fi
+	if [ "$HELP" = false ]
+	then
+		
+
+		bullet_patch
+		create_library_build_folders
+
+		if [ "$BUILDAI" = true ]
+		then
+			build_assimp
+		fi
+		copy_assimp
+		if [ "$BUILDOVR" = true ]
+		then
+			build_openvr
+		fi
+		copy_openvr
+	fi
+}
+
+if [ "$HELP" = false ]
+then
+	header_text
+fi
+
+main
+
+if [ "$HELP" = false ]
+then
+	footer_text
+fi

--- a/build-janusvr-linux.sh
+++ b/build-janusvr-linux.sh
@@ -129,17 +129,10 @@ bullet_patch () {
 	cp /usr/lib/x86_64-linux-gnu/libLinearMath.so.2.87		$BUILD_DIR
 }
 
-create_library_build_folders () {
-	echo -e "\n[*] Create Library build folder"
-	mkdir -p resources/build_dir/
-	mkdir -p resources/build_dir/assimp-5.0.1/
-	mkdir -p resources/build_dir/openvr-1.12.5/
-}
-
 build_assimp () {
-	echo -e "\n[*] Building ASSet IMPorter v5.0.1"
+	echo -e "\n[*] Building ASSet IMPorter v5"
 	echo -e "    ( this can be skipped by using the -a or --nobuildai flag )"
-	cd resources/assimp-5.0.1/
+	cd resources/assimp/
 	cmake .
 	make -j $NPROC
 	cd ../../
@@ -147,11 +140,7 @@ build_assimp () {
 
 copy_assimp () {
 	echo -e "\n[*] Copying assimp to $BUILD_DIR"
-	cp resources/assimp-5.0.1/bin/libassimp.so.5.0.1 $BUILD_DIR
-	cd $BUILD_DIR
-	ln -s libassimp.so.5.0.1 libassimp.so.5
-	ln -s libassimp.so.5.0.1 libassimp.so
-	cd ../../
+	cp resources/assimp/bin/libassimp.so.5 $BUILD_DIR/
 }
 
 build_openvr () {

--- a/build-janusvr-linux.sh
+++ b/build-janusvr-linux.sh
@@ -135,7 +135,7 @@ build_assimp () {
 	echo -e "\n[*] Building ASSet IMPorter v5.0.1"
 	echo -e "    ( this can be skipped by using the -a or --nobuildai flag )"
 	cd resources/build_dir/assimp-5.0.1/
-	cmake ../../assimp-5.0.1/ -B .
+	cmake ../../assimp-5.0.1/
 	make -j $NPROC
 	cd ../../../
 }

--- a/build-janusvr-linux.sh
+++ b/build-janusvr-linux.sh
@@ -90,8 +90,8 @@ header_text () {
 }
 
 footer_text () {
-	echo "\n[*] Done! Please run 'janusvr' from $BUILD_DIR"
-	echo "    ( Use -h or --help for build options )"
+	echo -e "\n[*] Done! Please run 'janusvr' from $BUILD_DIR"
+	echo -e "    ( Use -h or --help for build options )"
 }
 
 build_janus () {
@@ -139,15 +139,15 @@ create_library_build_folders () {
 build_assimp () {
 	echo -e "\n[*] Building ASSet IMPorter v5.0.1"
 	echo -e "    ( this can be skipped by using the -a or --nobuildai flag )"
-	cd resources/build_dir/assimp-5.0.1/
-	cmake ../../assimp-5.0.1/
+	cd resources/assimp-5.0.1/
+	cmake .
 	make -j $NPROC
-	cd ../../../
+	cd ../../
 }
 
 copy_assimp () {
 	echo -e "\n[*] Copying assimp to $BUILD_DIR"
-	cp resources/build_dir/assimp-5.0.1/code/libassimp.so.5.0.0 $BUILD_DIR
+	cp resources/assimp-5.0.1/lib/libassimp.so.5.0.0 $BUILD_DIR
 	cd $BUILD_DIR
 	ln -s libassimp.so.5.0.0 libassimp.so.5
 	ln -s libassimp.so.5.0.0 libassimp.so
@@ -157,14 +157,14 @@ copy_assimp () {
 build_openvr () {
 	echo -e "\n[*] Building OpenVR v1.12.5"
 	echo -e "    ( this can be skipped by using the -o or --nobuildovr flag )"
-	cd resources/build_dir/openvr-1.12.5/
-	cmake -B$(pwd)/ ../../openvr-1.12.5/
+	cd resources/openvr-1.12.5/
+	cmake .
 	make -j $NPROC
-	cd ../../../
+	cd ../../
 }
 
 copy_openvr () {
-	echo -e "\n[*] Copying OpenVR to $BUILD_DIR"
+	echo -e "[*] Copying OpenVR to $BUILD_DIR"
 	cp resources/openvr-1.12.5/bin/linux64/libopenvr_api.so $BUILD_DIR
 }
 
@@ -223,7 +223,7 @@ main () {
 		
 
 		bullet_patch
-		create_library_build_folders
+		#create_library_build_folders
 
 		if [ "$BUILDAI" = true ]
 		then

--- a/build-janusvr-linux.sh
+++ b/build-janusvr-linux.sh
@@ -67,7 +67,7 @@ pkglist=(
 	qtscript5-dev
 	mesa-common-dev
 	libilmbase-dev
-	libassimp-dev
+	#libassimp-dev
 	qtbase5-private-dev
 	libqt5webengine5
 	libqt5webenginecore5

--- a/build-janusvr-linux.sh
+++ b/build-janusvr-linux.sh
@@ -130,7 +130,7 @@ bullet_patch () {
 }
 
 build_assimp () {
-	echo -e "\n[*] Building ASSet IMPorter v5"
+	echo -e "\n[*] Building ASSet IMPorter v5.0.1"
 	echo -e "    ( this can be skipped by using the -a or --nobuildai flag )"
 	cd resources/assimp/
 	cmake .
@@ -140,7 +140,11 @@ build_assimp () {
 
 copy_assimp () {
 	echo -e "\n[*] Copying assimp to $BUILD_DIR"
-	cp resources/assimp/bin/libassimp.so.5 $BUILD_DIR/
+	cp resources/assimp/lib/libassimp.so.5.0.1 $BUILD_DIR
+	cd $BUILD_DIR
+	ln -s libassimp.so.5.0.1 libassimp.so.5
+	ln -s libassimp.so.5.0.1 libassimp.so
+	cd ../../
 }
 
 build_openvr () {

--- a/build-janusvr-linux.sh
+++ b/build-janusvr-linux.sh
@@ -33,8 +33,8 @@ pkglist=(
 	)
 
 # TODO: Enable automatic package installation via CLI flag
-#echo -e "\n[*] Installing prerequisite OS packages for Ubuntu 18.04"
-#sudo apt install ${pkglist[@]}
+echo -e "\n[*] Installing prerequisite OS packages for Ubuntu 18.04"
+sudo apt install ${pkglist[@]}
 
 echo "########################################################"
 echo " Welcome to the magical Linux Auto Compiler for JanusVR "


### PR DESCRIPTION
This works now, there is a problem on 18.04 IF libassimp-dev (v4.x.x) is installed where it causes janusvr to use that instead of the supplied libassimp.so.5.x.x.
